### PR TITLE
docs: replace the Supported providers list with a Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,32 @@ A tiny object storage SDK focused on uploading: Aliyun OSS, Tencent Cloud COS, H
 
 **Upgrading from 0.x? See the [upgrade guide](UPGRADING.md).**
 
-## Supported providers
+## Table of Contents
 
-- [Aliyun OSS (`tiny-oss`)](#usage) — the default entry
-- [AWS S3 (`tiny-oss/aws`)](#aws-s3) — SigV4 signing; also drives S3-compatible stores such as [MinIO, Cloudflare R2 and Google Cloud Storage](#s3-compatible-stores-minio-cloudflare-r2-google-cloud-storage-)
-- [Azure Blob Storage (`tiny-oss/azure`)](#azure-blob-storage)
-- [Huawei Cloud OBS (`tiny-oss/obs`)](#huawei-cloud-obs)
-- [Tencent Cloud COS (`tiny-oss/cos`)](#tencent-cloud-cos)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Basic](#basic)
+  - [Binding options once](#binding-options-once)
+  - [Upload progress](#upload-progress)
+  - [Upload callback](#upload-callback)
+  - [Protocol](#protocol)
+  - [Compatibility](#compatibility)
+  - [Non-browser environments](#non-browser-environments)
+- [Providers](#providers)
+  - [AWS S3](#aws-s3)
+  - [Tencent Cloud COS](#tencent-cloud-cos)
+  - [Huawei Cloud OBS](#huawei-cloud-obs)
+  - [Azure Blob Storage](#azure-blob-storage)
+- [Extension](#extension)
+  - [Composing a custom provider](#composing-a-custom-provider)
+  - [Contributing a provider to the repo](#contributing-a-provider-to-the-repo)
+- [API](#api)
+  - [options](#options)
+  - [put](#putoptions-objectname-blob-putoptions)
+  - [multipartUpload](#multipartuploadoptions-objectname-blob-multipartoptions)
+  - [putSymlink](#putsymlinkoptions-objectname-targetobjectname)
+  - [signatureUrl](#signatureurloptions-objectname-urloptions)
+- [LICENSE](#license)
 
 ## Installation
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -4,13 +4,32 @@
 
 **[English](README.md) | 简体中文**
 
-## 支持的存储服务
+## 目录
 
-- [阿里云 OSS（`tiny-oss`）](#使用) — 默认入口
-- [AWS S3（`tiny-oss/aws`）](#aws-s3) — SigV4 签名；同样适用于 S3 兼容存储，如 [MinIO、Cloudflare R2、Google Cloud Storage](#s3-compatible-stores-minio-cloudflare-r2-google-cloud-storage-)
-- [Azure Blob Storage（`tiny-oss/azure`）](#azure-blob-storage)
-- [华为云 OBS（`tiny-oss/obs`）](#华为云-obs)
-- [腾讯云 COS（`tiny-oss/cos`）](#腾讯云-cos)
+- [安装](#安装)
+- [使用](#使用)
+  - [基础使用](#基础使用)
+  - [绑定选项参数](#绑定选项参数)
+  - [上传进度](#上传进度)
+  - [上传回调](#上传回调)
+  - [协议](#协议)
+  - [兼容性](#兼容性)
+  - [非浏览器环境](#非浏览器环境)
+- [供应商](#供应商)
+  - [AWS S3](#aws-s3)
+  - [腾讯云 COS](#腾讯云-cos)
+  - [华为云 OBS](#华为云-obs)
+  - [Azure Blob Storage](#azure-blob-storage)
+- [扩展](#扩展)
+  - [组装自定义 provider](#组装自定义-provider)
+  - [向仓库贡献 provider](#向仓库贡献-provider)
+- [API](#api)
+  - [options](#options)
+  - [put](#putoptions-objectname-blob-putoptions)
+  - [multipartUpload](#multipartuploadoptions-objectname-blob-multipartoptions)
+  - [putSymlink](#putsymlinkoptions-objectname-targetobjectname)
+  - [signatureUrl](#signatureurloptions-objectname-urloptions)
+- [许可证协议](#许可证协议)
 
 ## 安装
 


### PR DESCRIPTION
Closes #28
loop-task: #28

## 需求
Replace the 'Supported providers' section with a Table of Contents (TOC lists H2 and H3 headings). Per the author's answers on #28: replace the list in place, all README files, old provider links dropped.

## 改动
- README.md: `## Supported providers` (5 provider links) → `## Table of Contents` (all H2 + indented H3)
- README_zh-CN.md: `## 支持的存储服务` → `## 目录`, mirrored structure

## 验证
- TOC anchors verified bidirectionally against all H2/H3 headings in both files (24/24, no dead links, no missing entries)