### PR TITLE
docs: extend needs-info close window to 30 days

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -6,7 +6,7 @@ Five canonical roles drive the loop:
 | Label | Meaning | Who acts next |
 | --- | --- | --- |
 | `needs-triage` | Needs a maintainer to evaluate (loop couldn't decide; too risky; external PR) | Maintainer |
-| `needs-info` | Waiting on the reporter: exact questions are in the comments | Reporter; loop closes after 7 days unanswered |
+| `needs-info` | Waiting on the reporter: exact questions are in the comments | Reporter; loop closes after 30 days unanswered |
 | `ready-for-agent` | Fully specified, an AFK agent may handle it unattended | Loop workflow (claims & processes) |
 | `ready-for-human` | Requires a human: implementation, merge of a loop PR, or a release call | Maintainer |
 | `wontfix` | Will not be actioned (duplicate / off-scope / pure question already answered) | — (issue closed with a reason) |

--- a/skills/sweep/SKILL.md
+++ b/skills/sweep/SKILL.md
@@ -16,7 +16,7 @@ description: Scheduled consistency pass over the loop system itself — reconcil
    - `waiting-merge` PR merged/closed since last run → record acceptance
      event if the dispatcher missed it (label it `sweep-corrected`).
 2. Expiry rules:
-   - `needs-info` unanswered > 7 days → close with comment, `status: closed`.
+   - `needs-info` unanswered > 30 days → close with comment, `status: closed`.
    - `waiting-merge` untouched > 14 days → comment nudge once; if the human
      then closes without merging → `rejected` (counted).
 3. Dependency/security notifications (Dependabot alert, security advisory


### PR DESCRIPTION
Norms-layer proposal (AGENTS.md: changes to skills/* and docs/agents/* are proposals — human merge required, not self-merged).

## Requirement
Owner directive (session, 2026-09-08): `needs-info` (needs-info 无人答复) should be closed after 30 days instead of 7.

## Changes
- `skills/sweep/SKILL.md` — expiry rule: `needs-info` unanswered > 7 days → > 30 days.
- `docs/agents/triage-labels.md` — needs-info row: "loop closes after 7 days unanswered" → 30 days.

Both places stating the rule updated; grep verified no other occurrences.

## Verification
- Rule text consistent across sweep skill and triage-labels reference.
- `waiting-merge` 14-day nudge rule untouched.