### PR TITLE
chore(loop): weekly retro schedule, credential guard, dependabot CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,17 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # The coverage step posts a PR comment. Dependabot-triggered runs get a
+    # read-only GITHUB_TOKEN by default (`pull_request` events from Dependabot
+    # are treated like fork PRs), which made that one step fail with
+    # "Resource not accessible by integration (HTTP 403)" — a red CI on every
+    # Dependabot PR while the tests themselves passed. Unlike a fork PR, a
+    # Dependabot run *can* be granted more: the `permissions` key is the
+    # documented way to widen the default scope. `contents: read` is kept for
+    # checkout; nothing else is needed.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/loop.yml
+++ b/.github/workflows/loop.yml
@@ -17,7 +17,14 @@ on:
   release:
     types: [published]
   schedule:
-    - cron: '17 3 * * *' # daily sweep; weekly retro cron: scripts/loop/shared/route.mjs WEEKLY_CRON
+    # Daily sweep: reconcile GitHub against the state layer, expire stale tasks,
+    # fold in dependency/security notices, refresh SUMMARY.
+    - cron: '17 3 * * *'
+    # Weekly retro: aggregate the two metrics and propose process changes.
+    # Must equal WEEKLY_CRON in scripts/loop/shared/route.mjs — the router
+    # compares the cron string exactly, so a typo here silently degrades to a
+    # sweep rather than failing loudly.
+    - cron: '23 3 * * 1'
   workflow_dispatch:
     inputs:
       task:

--- a/.github/workflows/loop.yml
+++ b/.github/workflows/loop.yml
@@ -17,7 +17,7 @@ on:
   release:
     types: [published]
   schedule:
-    - cron: '17 3 * * *' # daily sweep; weekly retro cron: scripts/loop/lib/route.mjs WEEKLY_CRON
+    - cron: '17 3 * * *' # daily sweep; weekly retro cron: scripts/loop/shared/route.mjs WEEKLY_CRON
   workflow_dispatch:
     inputs:
       task:

--- a/.github/workflows/loop.yml
+++ b/.github/workflows/loop.yml
@@ -59,6 +59,26 @@ jobs:
   loop:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    # Skip any `pull_request` run that cannot authenticate.
+    #
+    # `pull_request` is the only event we listen to where secrets can be absent:
+    # GitHub treats a Dependabot-triggered run like a fork run and issues a
+    # read-only token with **no secrets at all**, and a fork PR never has them.
+    # Unguarded, such a run dies at `Pull state from R2` and shows up as a red
+    # loop — indistinguishable from a real defect — while it cannot do anything
+    # useful anyway (no R2 credentials, no LLM key).
+    #
+    # `pull_request_target` (loop PR closed) does carry secrets, as do
+    # issues / schedule / release / workflow_dispatch, so those still run.
+    #
+    # Deliberately accepted for A1: read-only analysis of an external PR (host
+    # spec §6) therefore cannot run, because even a read-only analysis needs the
+    # LLM key. Enabling it means giving that path its own credentials — see D28
+    # in scripts/loop/README.md.
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.pull_request.head.repo.full_name == github.repository
+          && github.actor != 'dependabot[bot]')
     # Note: job-level env can only reference contexts like github / secrets / vars.
     # `inputs` is unavailable for non-workflow_dispatch events, and the `runner`
     # context exists only inside steps — neither belongs here (this once broke

--- a/scripts/loop/README.md
+++ b/scripts/loop/README.md
@@ -86,8 +86,7 @@ GitHub event ─▶ loop.yml (concurrency group `loop` = platform-level single w
 | `issues` opened/reopened | run(triage) |
 | `issues` edited, `issue_comment` created | inbox first (never silently dropped), then run per task status |
 | loop PR (`loop/<n>-*` **and** `loop-task: #<n>`) opened/synchronize | run(pr-review) |
-| dependabot PR (author `dependabot[bot]` or head `dependabot/*`) | run(deps) |
-| external PR (author_association ∉ OWNER/MEMBER/COLLABORATOR) | run(triage, readonly) |
+| same-repo PR, other branches | run(triage) — PRs are a triage surface |
 | `pull_request_review` on a loop PR | run(pr-review) |
 | `pull_request_target` closed (loop PR) | metrics: merged / closed-unmerged |
 | `release` published | metrics: released |
@@ -95,6 +94,24 @@ GitHub event ─▶ loop.yml (concurrency group `loop` = platform-level single w
 | `workflow_dispatch` | run per inputs (`task`/`stage`); `execute_writes=true` = L2 rehearsal |
 
 Anything else is a no-op that still exits 0 — event storms cost nothing.
+
+**Credential guard on `pull_request` (job-level `if`).** This is the only event
+we listen to where secrets can be absent: GitHub treats a Dependabot-triggered
+run like a fork run (read-only token, **no secrets at all**), and a fork PR
+never has them. Unguarded, such a run dies at `Pull state from R2` and looks
+exactly like a real defect. So a `pull_request` run is skipped unless the head
+repository is this one **and** the actor is not `dependabot[bot]`.
+
+The routing table above still describes what the *router* decides; the guard
+means two of those rows cannot actually run today:
+
+| Row | Status under A1 |
+| --- | --- |
+| external PR → run(triage, readonly) | **never runs** — even read-only analysis needs the LLM key. See D28. |
+| dependabot PR → run(deps) | **never runs** — no secrets. See D28. |
+
+`pull_request_target` (loop PR closed), `issues`, `schedule`, `release` and
+`workflow_dispatch` all keep their secrets and are unaffected.
 
 ### Outcomes: two vocabularies
 
@@ -275,9 +292,14 @@ was *correct*, and whether new events produce proposals that match reality.
       PR #36 has no labels and no label timeline events, and no item in the
       repository carries a loop label written by this run (the single
       `ready-for-human` hit is issue #30, closed on 09-08 during A0).
-- [ ] Every route has one real execution on Actions: issue triage / bugfix-feature
-      / deps / external-PR readonly / release preflight (deps and external-PR
-      were exercised locally during A0; `sweep` ran for real — run `34511392550`)
+- [ ] Every route that can run has one real execution on Actions: issue triage /
+      bugfix-feature / pr-review / sweep / release preflight. (`deps` and
+      external-PR are unrunnable under A1 — see D28 — and were exercised
+      locally during A0; `sweep` ran for real, run `34511392550`.)
+- [ ] **The guard holds**: a Dependabot PR and a fork PR both show the loop job
+      as *skipped* (not failed), while a same-repo PR and a loop PR still run.
+      Verify by pushing to a same-repo branch, and by observing the next
+      Dependabot PR arrive.
 - [ ] Serial lock: two consecutive dispatches queue, never run concurrently
       (run timestamps prove it)
 - [ ] Crash path: cancel a job mid-run → task stays `processing` → next sweep
@@ -373,12 +395,24 @@ was *correct*, and whether new events produce proposals that match reality.
 - [x] D20 (A1) Three comments still pointed at `scripts/loop/lib/` after the D10
       rename to `shared/`, and `run.mjs` named a `run-stage.mjs` that never
       existed (the orchestrator is `entry.mjs`). Spotted by a real run.
-- [ ] D21 (proposed by a real run, not yet implemented) The dependabot CI
-      failure is a *reporting* step, not a test failure: `Comment coverage on
-      PR` gets `gh: Resource not accessible by integration (HTTP 403)` because
-      GitHub forces the token read-only for Dependabot-triggered workflows.
-      `permissions:` cannot lift that. Needs a maintainer decision (guard the
-      step, `continue-on-error`, or move it to a `pull_request_target` job).
+- [x] D21 (A1) The dependabot CI failure was a *reporting* step, not a test
+      failure: `Comment coverage on PR` got `gh: Resource not accessible by
+      integration (HTTP 403)` because GitHub issues a read-only `GITHUB_TOKEN`
+      to Dependabot-triggered runs. An earlier note here claimed `permissions:`
+      could not lift that — wrong: that is the **fork** rule. Dependabot runs
+      *can* be widened, and the official docs name `permissions` as the fix.
+      The `test` job now declares `contents: read` + `pull-requests: write`, so
+      a Dependabot PR no longer shows a red CI whose tests all passed.
+- [ ] D28 (A1, open) Both `pull_request` rows that need no write access are
+      nevertheless unrunnable, because the platform withholds **all** secrets
+      (not just write permission) from Dependabot-triggered runs and from fork
+      PRs: even read-only analysis needs the LLM key, and `deps` needs the R2
+      credentials. The job-level guard skips them (see the trigger section) so
+      they fail visibly *before* wasting a runner rather than after pulling
+      state. Options when A1's week is over: a `pull_request_target` two-step
+      where only this repository's scripts run (§6's design), or Dependabot
+      secrets for `deps`. Chosen for A1: neither — the week is for validating
+      the run contract, and the guard keeps the red/green signal honest.
 - [x] D22 (A1) `renderSummary` had no section for `status: new`, so a task the
       sweep had just created was invisible in the human summary — the one item
       most in need of attention. Reported by a real sweep run; a `Unprocessed (new)`


### PR DESCRIPTION
Three fixes that landed **after** #36 was merged — they were pushed to the branch a minute too late to be included, so they are re-applied here on top of `main`. Nothing in #36 is reverted or rewritten; this is the tail of that work.

## 1. Wire the weekly retro schedule

The router already distinguished the weekly cron, but the workflow only declared the daily one, so `retro-scheduled` could never fire — the weekly self-optimisation pass was dead code:

```yaml
- cron: '17 3 * * *'   # daily sweep
- cron: '23 3 * * 1'   # weekly retro (Mondays 03:23 UTC)
```

The comment records why the string must match `WEEKLY_CRON` **exactly**: the router compares the cron value with equality, so a typo would silently run a sweep instead of failing loudly. Verified by parsing the cron values back out of the YAML and feeding them to the real router (`daily → sweep`, `weekly → retro-scheduled`), and by confirming that stage maps to `skills/retro/SKILL.md`.

## 2. Guard `pull_request` runs that have no secrets

`pull_request` is the only event we listen to where secrets can be absent — GitHub treats a Dependabot-triggered run like a fork run (read-only token, **no secrets at all**), and a fork PR never has them. Unguarded, such a run dies at `Pull state from R2` and shows up as a red `loop`: indistinguishable from a real defect, while it cannot do anything useful anyway.

```yaml
if: >-
  github.event_name != 'pull_request'
  || (github.event.pull_request.head.repo.full_name == github.repository
      && github.actor != 'dependabot[bot]')
```

Verified across 12 event shapes: every event carrying secrets still runs, Dependabot and fork PRs skip, and a missing head repository falls back to skipping.

**Consequence, accepted deliberately for A1** (recorded as D28): the router's `deps` and external-PR `readonly` rows cannot actually run, because even a read-only analysis needs the LLM key. Enabling them later means giving that path its own credentials (`pull_request_target` two-step per host spec §6, or Dependabot secrets). The trigger table in `scripts/loop/README.md` now marks both rows as unrunnable so the docs match reality.

## 3. Fix the Dependabot red CI (D21)

`Comment coverage on PR` failed with `Resource not accessible by integration (HTTP 403)`: GitHub issues a read-only `GITHUB_TOKEN` to Dependabot-triggered runs. The `test` job now grants `pull-requests: write`, so a Dependabot PR no longer reports a failed CI whose tests all passed.

**Correction worth noting:** I earlier claimed in #36 that `permissions:` could not lift this. That is the **fork** rule, not the Dependabot one — the official docs name `permissions` as the fix for Dependabot runs. The defect log has been corrected rather than quietly deleted.

## Also

`4691a27`-equivalent: a stale path in the cron comment still pointed at `scripts/loop/lib/route.mjs` after the D10 rename to `shared/`.

`actionlint` clean on both workflows; local regression suite (route decisions 17/17, failure classification 9/9, CLI flow with its guards, all orchestrator paths) still green.