### PR TITLE
chore(loop): limit the D9 reopen check to terminal states

### DIFF
--- a/scripts/loop/README.md
+++ b/scripts/loop/README.md
@@ -403,16 +403,6 @@ was *correct*, and whether new events produce proposals that match reality.
       *can* be widened, and the official docs name `permissions` as the fix.
       The `test` job now declares `contents: read` + `pull-requests: write`, so
       a Dependabot PR no longer shows a red CI whose tests all passed.
-- [ ] D28 (A1, open) Both `pull_request` rows that need no write access are
-      nevertheless unrunnable, because the platform withholds **all** secrets
-      (not just write permission) from Dependabot-triggered runs and from fork
-      PRs: even read-only analysis needs the LLM key, and `deps` needs the R2
-      credentials. The job-level guard skips them (see the trigger section) so
-      they fail visibly *before* wasting a runner rather than after pulling
-      state. Options when A1's week is over: a `pull_request_target` two-step
-      where only this repository's scripts run (§6's design), or Dependabot
-      secrets for `deps`. Chosen for A1: neither — the week is for validating
-      the run contract, and the guard keeps the red/green signal honest.
 - [x] D22 (A1) `renderSummary` had no section for `status: new`, so a task the
       sweep had just created was invisible in the human summary — the one item
       most in need of attention. Reported by a real sweep run; a `Unprocessed (new)`
@@ -449,6 +439,29 @@ was *correct*, and whether new events produce proposals that match reality.
       orchestrator, which needs the failure) while a CLI should not. `main` now
       wraps dispatch, so every subcommand reports the same way. Found while
       reviewing the translated error messages.
+- [ ] D28 (A1, open) Both `pull_request` rows that need no write access are
+      nevertheless unrunnable, because the platform withholds **all** secrets
+      (not just write permission) from Dependabot-triggered runs and from fork
+      PRs: even read-only analysis needs the LLM key, and `deps` needs the R2
+      credentials. The job-level guard skips them (see the trigger section) so
+      they fail visibly *before* wasting a runner rather than after pulling
+      state. Options when A1's week is over: a `pull_request_target` two-step
+      where only this repository's scripts run (§6's design), or Dependabot
+      secrets for `deps`. Chosen for A1: neither — the week is for validating
+      the run contract, and the guard keeps the red/green signal honest.
+- [x] D29 (A1) D9's reopen check fired on **any** non-claimable status, not just
+      the terminal ones. A `waiting-human` task (the inbox) is open on GitHub by
+      definition, so a single `start --task` "reopened" it: the status was reset
+      to `ready`, the triage decision was **wiped**, and a bogus `reopened` event
+      was appended — silently converting an inbox item into an auto-claimable one
+      and bypassing the cognitive guard. `waiting-merge` was affected the same
+      way. The README entry for D9 always said `closed/rejected`; the
+      implementation was broader than its own description. The check is now
+      limited to `closed`/`rejected`, and the not-claimable error tells you what
+      the state actually requires (inbox → a human decides first; waiting-merge →
+      awaiting merge). Verified across five scenarios: inbox and awaiting-merge
+      are refused without touching the decision, `closed` + a genuinely reopened
+      GitHub item is still let through, and `closed` + a closed item is not.
 
 ## Environment facts
 

--- a/scripts/loop/run.mjs
+++ b/scripts/loop/run.mjs
@@ -138,9 +138,16 @@ async function cmdStart(args) {
   }
 
   // Claim check: new/ready/waiting-info are claimable; a live processing lock
-  // refuses the claim, an expired one can be overridden; a terminal task whose
-  // GitHub issue was reopened → reset to ready and claim again (D9)
+  // refuses the claim, an expired one can be overridden; a task the loop had
+  // already closed, whose GitHub item was reopened, is reset to ready (D9).
   const claimable = ['new', 'ready', 'waiting-info'];
+  // D9 applies to terminal states only. `accepted` is terminal but means
+  // "delivered and merged", and `waiting-human`/`waiting-merge` are open by
+  // definition — a waiting-human task is in the inbox *because* a human must
+  // decide, so finding its GitHub item open is the normal case, not a reopen.
+  // Treating any non-claimable state as reopened silently turned inbox tasks
+  // into auto-claimable ones and wiped their triage decision.
+  const reopenable = ['closed', 'rejected'];
   if (t.status === 'processing') {
     if (!lockExpired(t.lockedBy)) {
       fail(`task #${t.id} is held by ${t.lockedBy?.runId ?? '?'} (status=processing), ` +
@@ -148,7 +155,7 @@ async function cmdStart(args) {
     }
     console.warn(`[loop] warn: task #${t.id} lock expired ` +
       `(${t.lockedBy?.runId}), taking over to resume`);
-  } else if (!claimable.includes(t.status) && t.url) {
+  } else if (reopenable.includes(t.status) && t.url) {
     const repo = repoOf(t.url);
     const ghState = repo
       ? spawnSync('gh', ['issue', 'view', String(t.id), '-R', repo, '--json', 'state', '-q', '.state'], { encoding: 'utf8' })
@@ -163,8 +170,12 @@ async function cmdStart(args) {
     }
   }
   if (!claimable.includes(t.status)) {
-    fail(`task #${t.id} status=${t.status} is not claimable (claimable: ${claimable.join('/')}); ` +
-      `terminal tasks whose GitHub issue was reopened are let through`);
+    const hint = t.status === 'waiting-human'
+      ? 'it is in the human inbox — a human decides first (label/status), then it can be claimed'
+      : t.status === 'waiting-merge'
+        ? 'it is awaiting a human merge'
+        : `terminal states (${reopenable.join('/')}) whose GitHub item was reopened are let through`;
+    fail(`task #${t.id} status=${t.status} is not claimable (claimable: ${claimable.join('/')}); ${hint}`);
   }
 
   const rid = await beginRun(S, t, s, { sandbox: `local:${process.platform}`, trigger: 'manual' });


### PR DESCRIPTION
Fixes a guard bypass found while closing #21.

## The defect

D9's reopen check fired on **any** non-claimable status:

```js
} else if (!claimable.includes(t.status) && t.url) {   // <- too broad
```

A `waiting-human` task is in the human inbox *because* a human must decide, so its GitHub item being open is the **normal** case — not a reopen. As written, one `pnpm loop start --task <n>` on an inbox task would:

- reset its status to `ready`,
- **wipe its triage decision** (the record of *why* it went to the inbox),
- append a bogus `reopened` event,
- and hand it back as auto-claimable.

Reproduced before fixing, on the real task #21 (`waiting-human`, `needs-triage`):

```
before: status=waiting-human  decision=True   labels=[needs-triage]
warn:   task #21 local status=waiting-human, GitHub issue reopened -> reset to ready (D9)
after:  status=processing     decision=None
```

`waiting-merge` was affected the same way. This is the cognitive guard bypassed by a single command — and the README entry for D9 has always said `closed`/`rejected`, so the implementation was broader than its own description, which is why it read as intended behaviour.

## The fix

- The check now applies to `closed`/`rejected` only. `accepted` is terminal too, but means "delivered and merged"; neither the inbox nor awaiting-merge should ever be reset.
- The not-claimable error now says what the state actually requires: an inbox task needs a human decision first, an awaiting-merge task needs a merge — instead of the previous catch-all hint about reopened items.

## Verified, five scenarios

| Scenario | Expected | Result |
| --- | --- | --- |
| `waiting-human` + GitHub open | refuse, decision intact | pass |
| `waiting-merge` + GitHub open | refuse, decision intact | pass |
| `closed` + GitHub genuinely open | allow (D9's original purpose) | pass |
| `closed` + GitHub merged | refuse (not reopened) | pass |
| `new` / `ready` / `waiting-info` | still claimable | pass |

Plus the standing regression suite (route decisions, stage whitelist, run-closing idempotence, orchestrator paths) — all green.

## Also in this PR

`scripts/loop/README.md` gains D29, and the defect log is reordered so numbering is monotonic from D10 on. The first eight entries keep their original A0-era discovery order — that is history, not a tidy-up target.

## Context

`#21` (Spanish README) was closed as `wontfix` while investigating this: the translation targets the 0.x class API and the project keeps two README variants by policy (#30). External PRs never enter the acceptance metric, so no acceptance row was written; the task file was moved to `closed` with a human-attributed timeline entry.
