### PR TITLE
chore(loop): correct the D33 note (dependabot PRs never reach triage)

### DIFF
--- a/scripts/loop/README.md
+++ b/scripts/loop/README.md
@@ -515,15 +515,25 @@ was *correct*, and whether new events produce proposals that match reality.
       returned `noop` for any PR without `loop-task:`, which is right about the
       **metric** (not loop-produced ⇒ never in the acceptance rate) but wrong
       about the **task**: ops.md maps "(none, merged) → accepted" and "(none,
-      closed unmerged) → rejected" regardless of provenance. Every owner or
-      dependabot PR gets a task from `pull_request` triage, so each merged PR left
-      a zombie in `waiting-human` — the task for the very PR that fixed D30 (#39)
-      demonstrated it live — visible forever under "Inbox" in SUMMARY.md and
+      closed unmerged) → rejected" regardless of provenance. Every owner PR gets a
+      task from `pull_request` triage, so each merge left a zombie in
+      `waiting-human` — the task for the very PR that fixed D30 (#39) showed it
+      live — visible forever under "Inbox" in SUMMARY.md and, in general,
       uncorrectable by sweep, which lists *open* GitHub items and so cannot see a
-      closure. The router now emits a `terminal` decision for that case; the
-      entry handles it through the same `markTaskTerminal` as the metrics path, so
-      "what terminal means" has one definition, and the acceptance row is still
-      never written for a non-loop PR.
+      closure. (Dependabot PRs are skipped before triage by the credential guard
+      (D28), so for them the new branch is a no-op; it still matters if D28 is
+      ever lifted, and it correctly terminalises the older dependabot task #35.)
+      The router now emits a `terminal` decision for that case; the entry handles
+      it through the same `markTaskTerminal` as the metrics path, so "what
+      terminal means" has one definition, and the acceptance row is still never
+      written for a non-loop PR.
+      Verified live on 2026-09-11 (`34595150462`, PR #40 merged): `task #40:
+      waiting-human → accepted`, and R2 then reported `closed=1 accepted=9` with
+      acceptance rows still at 3 — no metric for a non-loop PR.
+      The #39 instance was **not** this fix's doing: the drift was self-healed by
+      the 09-11 daily sweep (`r-20260911-080231-zja0`), which only found it
+      because the #40 triage report had mentioned it in passing. That is the
+      accidental path D30/D33 exist to remove.
 
 ## Environment facts
 

--- a/scripts/loop/shared/route.mjs
+++ b/scripts/loop/shared/route.mjs
@@ -143,10 +143,11 @@ export function route({ eventName, action, event = {} }) {
       // Not loop-produced, so it must not enter the acceptance metric — but its own
       // task still has to reach a terminal state, or it sits in the inbox forever
       // (ops.md maps "(none, merged) -> accepted", "(none, closed unmerged) ->
-      // rejected"). Every owner/dependabot PR gets a task from `pull_request`
-      // triage, so without this each one strands a zombie in the state layer, and
-      // sweep cannot repair it: sweep lists *open* GitHub items, which cannot see
-      // a closure.
+      // rejected"). Every owner PR gets a task from `pull_request` triage, so
+      // without this each merge strands a zombie in the state layer, and sweep
+      // cannot repair it: sweep lists *open* GitHub items, which cannot see a
+      // closure. (Dependabot PRs are skipped before triage by the credential
+      // guard, D28, so for them this branch is a no-op.)
       return terminal({
         reason: `non-loop PR ${merged ? 'merged' : 'closed-unmerged'} `
           + '(not counted for auto-acceptance)',


### PR DESCRIPTION
Small correction to my own #40. No behaviour change.

## What was wrong

The D33 note claimed:

> Every owner **or dependabot** PR gets a task from `pull_request` triage

Dependabot is not one of them. The credential guard (D28) skips the whole job before triage, because a Dependabot-triggered `pull_request` run gets a read-only token and **no secrets at all**. So the new `terminal` branch is a no-op for dependabot closures.

The **code was always right** — `markTaskTerminal` treats a missing task as `no transition needed`, which I tested. Only the reasoning was wrong. Worth fixing anyway: the note is what the next reader trusts, and a wrong premise there invites a wrong change later. It still matters if D28 is ever lifted, and it does correctly terminalise the older dependabot task #35 (created before the guard).

## D33 verified live

`34595150462`, the `pull_request_target.closed` run for #40's merge:

```
[loop] event=pull_request_target.closed → terminal (non-loop PR merged (not counted for auto-acceptance))
[loop] task #40: waiting-human → accepted (non-loop PR merged (not counted for auto-acceptance))
```

Both halves hold, confirmed against R2 (the authority, not the local mirror):

| | expected | R2 |
| --- | --- | --- |
| task #40 | `accepted` | `tasks: 10 (closed=1, accepted=9)` |
| acceptance rows | still 3 | `acceptance rows: 3` |

Worth noting the run checked out `f9b8278` — this PR's own head, via the D24 same-repo-PR rule — so the run that terminalised #40 was already executing the fix.

## A correction to how D33 reads

The #39 drift did **not** wait for this fix. The 2026-09-11 daily sweep (`r-20260911-080231-zja0`) found and reconciled it:

> task #39 was stranded … `status: waiting-human` → `accepted`, no acceptance row written

But read the sweep's own §7.1:

> The `sweep` skill cannot see closures … **this run only caught it because the previous triage run had flagged it**

That is the whole point. The reconciliation happened because the #40 triage report had mentioned #39 in passing — one run's prose reaching the next day's sweep. If that sentence had not been there, #39 would still be sitting in the inbox.

So sweep's structural blind spot is **not** fixed; it is now demonstrated by a case where the drift was real, lasted ~13 hours, and was only closed by an accident. The norms-layer fix (sweep should reconcile closure-direction drift, e.g. task `updatedAt` vs GitHub `mergedAt`/`closedAt`) stays a proposal for after A1's observation week — this PR only makes the defect log say so accurately.
