### PR TITLE
chore(loop): expose the engine model to workflow_dispatch, and fix the push-after-skipped-pull failure (D34)

### DIFF
--- a/.github/workflows/loop.yml
+++ b/.github/workflows/loop.yml
@@ -169,6 +169,7 @@ jobs:
           echo "model $want is available"
 
       - name: Pull state from R2
+        id: pull
         run: node scripts/loop/r2-sync.mjs pull
 
       - name: Run stage
@@ -177,9 +178,18 @@ jobs:
         run: node scripts/loop/entry.mjs
 
       # Push the state layer back even on crash/timeout (the task stays in
-      # processing and is reclaimed by the next sweep via TTL)
+      # processing and is reclaimed by the next sweep via TTL).
+      #
+      # Guarded on `pull` having *run*: `state/` is gitignored, so it exists only
+      # after a pull. If an earlier step failed, pull is skipped, the directory
+      # never appears, and an unguarded push dies on
+      # `aws: [ERROR]: The user-provided path ... does not exist` — a second red
+      # step that buries the real cause and reads like R2 itself broke (D34).
+      # `!= 'skipped'` rather than `== 'success'` on purpose: a *failed* pull may
+      # still have left a usable tree, and the point of `always()` is to record
+      # the processing state after a mid-run crash.
       - name: Push state to R2
-        if: always()
+        if: always() && steps.pull.outcome != 'skipped'
         run: node scripts/loop/r2-sync.mjs push
 
       - name: Upload session transcripts

--- a/.github/workflows/loop.yml
+++ b/.github/workflows/loop.yml
@@ -42,6 +42,9 @@ on:
         description: 'Infrastructure only: exercise checkout/install/R2 pull+push, skip the agent'
         required: false
         default: 'false'
+      model:
+        description: 'Override the engine model id (default deepseek/deepseek-v4-flash). A bad value must fail the D19 guard.'
+        required: false
 
 concurrency:
   group: loop
@@ -91,7 +94,7 @@ jobs:
       # For non-dispatch events github.event.inputs is null → default to report (report-only)
       LOOP_EXECUTE_WRITES: ${{ github.event.inputs.execute_writes || 'false' }}
       LOOP_SMOKE: ${{ github.event.inputs.smoke || 'false' }}
-      LOOP_MODEL: deepseek/deepseek-v4-flash
+      LOOP_MODEL: ${{ github.event.inputs.model || 'deepseek/deepseek-v4-flash' }}
       LOOP_RUN_TIMEOUT_MS: '3300000' # 55min, leaving headroom for push (job timeout 60min)
       GH_TOKEN: ${{ secrets.LOOP_GH_TOKEN || github.token }}
       # Credentials: secrets only

--- a/scripts/loop/README.md
+++ b/scripts/loop/README.md
@@ -92,7 +92,7 @@ GitHub event ─▶ loop.yml (concurrency group `loop` = platform-level single w
 | `pull_request_target` closed (other PR) | task → `accepted` / `rejected` only; **no metric** (not loop-produced) |
 | `release` published | metrics: released |
 | `schedule` daily / weekly | system run: sweep / retro-scheduled |
-| `workflow_dispatch` | run per inputs (`task`/`stage`); `execute_writes=true` = L2 rehearsal |
+| `workflow_dispatch` | run per inputs (`task`/`stage`); `model` overrides the engine model; `execute_writes=true` = L2 rehearsal |
 
 Anything else is a no-op that still exits 0 — event storms cost nothing.
 
@@ -307,10 +307,25 @@ was *correct*, and whether new events produce proposals that match reality.
       as *skipped* (not failed), while a same-repo PR and a loop PR still run.
       Verify by pushing to a same-repo branch, and by observing the next
       Dependabot PR arrive.
-- [ ] Serial lock: two consecutive dispatches queue, never run concurrently
-      (run timestamps prove it)
+- [x] Serial lock: two consecutive dispatches queue, never run concurrently —
+      verified 2026-09-11 with two `workflow_dispatch` runs 25s apart
+      (`34607797259`, `34607838545`). The evidence is at **job** level, not
+      workflow: run 2's workflow `created_at` is 14:03:03 but its job
+      `created_at` is 14:03:07 — exactly run 1's job `completed_at` — and its
+      "Set up job" logs at 14:03:10. Workflow-level `created == started` on both,
+      so read alone it would have looked like concurrency; the job timestamps
+      show the 4s queue.
 - [ ] Crash path: cancel a job mid-run → task stays `processing` → next sweep
-      reclaims it by TTL
+      reclaims it by TTL. Still unsampled — and the model-guard runs show why the
+      cheap version of this test cannot work: the failure lands in `Install
+      engine (pi)`, *before* `Run stage`, so no task is ever claimed (`Pull state`
+      and `Run stage` both skipped). It needs a job actually cancelled after
+      `entry.mjs` has claimed a task.
+- [ ] Failure classification (`retry` vs inbox) — **still unexercised even though
+      a failing run now exists.** The D19 guard failure is a *workflow step*
+      failure: `entry.mjs` never ran, so no run row was written and the
+      classification table was never consulted. Only an in-agent failure (engine
+      crash, non-zero exit after a claim) exercises it.
 - [ ] Metrics — **unreachable under A1; accepted unverified (2026-09-11)**: a
       human merge writes one `acceptance` row, no duplicates; `released`
       backfills to the intended task. A1 produces no loop PR, so the `metrics`
@@ -572,6 +587,21 @@ that has never met production.
       the 09-11 daily sweep (`r-20260911-080231-zja0`), which only found it
       because the #40 triage report had mentioned it in passing. That is the
       accidental path D30/D33 exist to remove.
+- [x] D34 (A1) `Push state to R2` failed whenever `Pull state from R2` was
+      skipped. The push is `if: always()` so that a run which crashes or times
+      out still records its `processing` state for the next sweep — but
+      `state/` is gitignored and materialises only from a pull, so when an
+      earlier step fails there is no directory to upload and the step dies on
+      `aws: [ERROR]: The user-provided path ... does not exist` (exit 255,
+      observed on `34607797259` and `34607838545`, both after the D19 model
+      guard rejected a deliberately bad model). The job was already failing, so
+      the verdict was unchanged — but a second red step buries the first cause
+      and reads like R2 itself broke, which is exactly the kind of noise a
+      report-only phase must not generate while a human is reading logs daily.
+      Now the pull has an `id` and the push is conditioned on
+      `always() && steps.pull.outcome != 'skipped'`. Deliberately not
+      `== 'success'`: a *failed* pull may still leave a usable tree, and
+      recording post-crash state is the whole point of `always()`.
 
 ## Environment facts
 

--- a/scripts/loop/README.md
+++ b/scripts/loop/README.md
@@ -344,10 +344,13 @@ was *correct*, and whether new events produce proposals that match reality.
       (outcome, exit code, token usage, model, proposed actions) without
       downloading anything
 - [ ] Engine stability: N consecutive headless pi runs without hanging — all 18
-      recorded runs reached an end row with no hang (A0 + A1 combined). Note the
-      inverse gap: **every run so far exited 0**, so the failure-classification
-      table (machine/config failure → `retry`; agent-judged → inbox) has never
-      been exercised by a real failure.
+      **recorded** runs reached an end row with no hang (A0 + A1 combined). Note
+      the inverse gap: every recorded run exited 0, so the classification table
+      (machine/config failure → `retry`; agent-judged → inbox) has never been
+      consulted. The three guard failures do not change this: they die at
+      `Install engine (pi)`, before `entry.mjs`, so they write no run row at all
+      — see the failure-classification item above. (Distinction worth keeping:
+      21 workflow executions, 18 run records.)
 - [ ] No drift **and** no incorrect proposal after a week → human decides on L2
 
 ### Not reachable under A1 (structural — decide before the L2 switchover)
@@ -602,6 +605,9 @@ that has never met production.
       `always() && steps.pull.outcome != 'skipped'`. Deliberately not
       `== 'success'`: a *failed* pull may still leave a usable tree, and
       recording post-crash state is the whole point of `always()`.
+      Verified on `34608064576` (same bad model after the fix): step 9 is now
+      `skipped` while step 6 stays `failure`, so the only red step is the one
+      that actually failed.
 
 ## Environment facts
 


### PR DESCRIPTION
Executes the A1 sample-gathering test I proposed, and it paid for itself: the guard works, the serial lock is proven, and the test exposed a real defect (D34).

## 1. The guard holds — D19 verified for the first time

`workflow_dispatch` had no model input (`LOOP_MODEL` was a hardcoded job env), so a bad model could not be produced at all. Added an optional `model` input, defaulting to the same id as before; validation is unchanged.

Dispatching with `nonexistent/model-xyz`:

```
provider  model                         context  max-out  thinking  images
deepseek  deepseek-v4-flash             1M       384K     yes       no
deepseek  deepseek-v4-flash-vision-exp  1M       384K     yes       yes
deepseek  deepseek-v4-pro               1M       384K     yes       no
##[error]LOOP_MODEL=nonexistent/model-xyz not in pi's DeepSeek catalog (want 'model-xyz')
##[error]Process completed with exit code 1.
```

Fails loudly, names the want/actual, prints the catalog. Zero LLM tokens — the guard trips before the agent. This closes the "the guard was never tested with a real bad value" gap.

## 2. Serial lock — proven, with a caveat about how you read the timestamps

Two dispatches 25s apart:

| | workflow `createdAt` | job `created_at` | job `completed_at` |
| --- | --- | --- | --- |
| run 1 | 14:02:38 | 14:02:42 | 14:03:07 |
| run 2 | 14:03:03 | **14:03:07** | 14:03:36 |

Run 2 entered the queue at 14:03:03, but its **job** was not created until 14:03:07 — exactly run 1's job `completed_at` — and "Set up job" logs at 14:03:10. A 4s queue.

The trap: at workflow level `created == started` for both runs, so reading those alone would look like they ran concurrently. Only the job-level timestamps show the serialization. Worth recording, because "R2 has no concurrent writes" rests on this.

## 3. D34 — a second red step that buried the first cause

Every one of the failing runs showed:

```
9 Push state to R2 → failure
```

```
[loop:r2] push ← /home/runner/work/tiny-oss/tiny-oss/state
aws: [ERROR]: The user-provided path /home/runner/work/tiny-oss/tiny-oss/state does not exist.
[loop:r2] error: [r2:push] aws cli exited with code 255
```

`state/` is gitignored and only materialises from a pull. The push is `if: always()` — correct intent (a crashed run must still record its `processing` state for the next sweep) — but with `Pull state from R2` skipped there is nothing to upload.

The verdict did not change (the job was already failing), but this is the phase where a human reads these logs daily: two red steps read like *R2 also broke*, and the second failure is pure noise on top of the real one.

Fix: the pull gets an `id`, the push is conditioned on

```yaml
if: always() && steps.pull.outcome != 'skipped'
```

`!= 'skipped'` rather than `== 'success'` deliberately — a *failed* pull may still leave a usable tree, and recording post-crash state is precisely what `always()` is for.

Verified on the same bad model after the fix (`34608064576`): step 9 is now `skipped`, step 6 stays `failure`. The only red step is the one that genuinely failed.

## 4. What this test did *not* establish

Recording these because I proposed this test partly on the expectation it would cover them, and it does not:

| A1 item | status after this test |
| --- | --- |
| Crash path (task stays `processing` → sweep reclaims by TTL) | **still unsampled.** The failure lands in `Install engine (pi)`, *before* `Run stage`, so no task is ever claimed — steps 7 and 8 were both `skipped`. Needs a job cancelled *after* `entry.mjs` claims. |
| Failure classification (`retry` vs inbox) | **still unexercised.** A guard failure is a *workflow step* failure: `entry.mjs` never ran, so no run row exists and the classification table was never consulted. |

Both are now written into the A1 checklist with the reason they cannot be tested this way, so the next person does not repeat the attempt.

## Verification

- `actionlint` clean on both workflows.
- PR #43 has since merged, which put this branch in conflict on the A1 checklist —
  both PRs had extended the same list. Resolved by keeping **both** intents
  rather than picking a side: #44's Crash-path and new Failure-classification
  items, plus #43's fuller Metrics entry.
- The rebase also reconciled one number. The guard failures do **not** add run
  records — they die at `Install engine (pi)`, before `entry.mjs`, so no run row
  is ever written. That is 21 workflow executions but still 18 run records, and
  the engine-stability count now says exactly that.
- CI re-run after the rebase: Lint / Test / loop all pass, `mergeable=CLEAN`.
